### PR TITLE
Switch to Debian 11(bullseye) in order to remediate multiple vulnerabilities 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 
 # Bazel
 bazel-*
+
+# IDE
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,32 @@
-FROM golang:alpine
-MAINTAINER Misha Seltzer
+FROM golang:bullseye
 
-COPY proxy/proxy.go /go/src/github.com/mishas/prometheus_amqp_proxy/proxy/
-COPY proxy/rpc/*.go /go/src/github.com/mishas/prometheus_amqp_proxy/proxy/rpc/
+ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apk add --update git \
- && go get -v -d github.com/streadway/amqp \
- && go install -v github.com/mishas/prometheus_amqp_proxy/proxy/rpc \
- && go install -v github.com/mishas/prometheus_amqp_proxy/proxy \
- && apk del --purge git && rm -rf /var/cache/apk/*
+RUN echo 'APT::Install-Recommends "false";' >> /etc/apt/apt.conf.d/99_norecommends \
+ && echo 'APT::AutoRemove::RecommendsImportant "false";' >> /etc/apt/apt.conf.d/99_norecommends \
+ && echo 'APT::AutoRemove::SuggestsImportant "false";' >> /etc/apt/apt.conf.d/99_norecommends
 
+# Set the working directory
+WORKDIR /go/src/github.com/mishas/prometheus_amqp_proxy
+
+# Copy the source files
+COPY proxy/proxy.go proxy/
+COPY proxy/rpc/*.go proxy/rpc/
+
+# Install git, initialize Go module, install dependencies, and build binaries
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+ && cd /go/src/github.com/mishas/prometheus_amqp_proxy \
+ && go mod init github.com/mishas/prometheus_amqp_proxy \
+ && go get github.com/streadway/amqp@latest \
+ && go mod tidy \
+ && go build -o /bin/proxy ./proxy \
+ && go build -o /bin/rpc ./proxy/rpc \
+ && apt-get autoremove -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# Expose the necessary port
 EXPOSE 8200
 
-ENTRYPOINT ["bin/proxy"]
-
+# Set the entry point
+ENTRYPOINT ["/bin/proxy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN echo 'APT::Install-Recommends "false";' >> /etc/apt/apt.conf.d/99_norecommen
  && echo 'APT::AutoRemove::RecommendsImportant "false";' >> /etc/apt/apt.conf.d/99_norecommends \
  && echo 'APT::AutoRemove::SuggestsImportant "false";' >> /etc/apt/apt.conf.d/99_norecommends
 
-# Install necessary packages
 RUN apt-get update && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
     git \
@@ -15,14 +14,11 @@ RUN apt-get update && apt-get upgrade -y \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-# Set the working directory
 WORKDIR /go/src/github.com/mishas/prometheus_amqp_proxy
 
-# Copy the source files
 COPY proxy/proxy.go proxy/
 COPY proxy/rpc/*.go proxy/rpc/
 
-# Initialize Go module, install dependencies, and build binaries
 RUN cd /go/src/github.com/mishas/prometheus_amqp_proxy \
  && go mod init github.com/mishas/prometheus_amqp_proxy \
  && go get github.com/streadway/amqp@latest \
@@ -30,8 +26,6 @@ RUN cd /go/src/github.com/mishas/prometheus_amqp_proxy \
  && go build -o /bin/proxy ./proxy \
  && go build -o /bin/rpc ./proxy/rpc
 
-# Expose the necessary port
 EXPOSE 8200
 
-# Set the entry point
 ENTRYPOINT ["/bin/proxy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
-FROM golang:bullseye
+FROM debian:11.8-slim@sha256:d66e51af682be02ff054f86dc0c07366c0a40c6de3d8f1c731de3c633da56847
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN echo 'APT::Install-Recommends "false";' >> /etc/apt/apt.conf.d/99_norecommends \
  && echo 'APT::AutoRemove::RecommendsImportant "false";' >> /etc/apt/apt.conf.d/99_norecommends \
  && echo 'APT::AutoRemove::SuggestsImportant "false";' >> /etc/apt/apt.conf.d/99_norecommends
+
+# Install necessary packages
+RUN apt-get update && apt-get upgrade -y \
+ && apt-get install -y --no-install-recommends \
+    git \
+    golang \
+    ca-certificates \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory
 WORKDIR /go/src/github.com/mishas/prometheus_amqp_proxy
@@ -13,17 +22,13 @@ WORKDIR /go/src/github.com/mishas/prometheus_amqp_proxy
 COPY proxy/proxy.go proxy/
 COPY proxy/rpc/*.go proxy/rpc/
 
-# Install git, initialize Go module, install dependencies, and build binaries
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
- && cd /go/src/github.com/mishas/prometheus_amqp_proxy \
+# Initialize Go module, install dependencies, and build binaries
+RUN cd /go/src/github.com/mishas/prometheus_amqp_proxy \
  && go mod init github.com/mishas/prometheus_amqp_proxy \
  && go get github.com/streadway/amqp@latest \
  && go mod tidy \
  && go build -o /bin/proxy ./proxy \
- && go build -o /bin/rpc ./proxy/rpc \
- && apt-get autoremove -y \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+ && go build -o /bin/rpc ./proxy/rpc
 
 # Expose the necessary port
 EXPOSE 8200


### PR DESCRIPTION
**Before:**
```
$ grype --only-fixed mishasel/prometheus_amqp_proxy

NAME          INSTALLED  FIXED-IN    TYPE  VULNERABILITY   SEVERITY
busybox       1.24.2-r8  1.24.2-r13  apk   CVE-2017-16544  High
busybox       1.24.2-r8  1.24.2-r12  apk   CVE-2016-6301   High
busybox       1.24.2-r8  1.24.2-r13  apk   CVE-2017-15873  Medium
libcrypto1.0  1.0.2h-r0  1.0.2h-r3   apk   CVE-2016-6303   Critical
libcrypto1.0  1.0.2h-r0  1.0.2h-r3   apk   CVE-2016-2182   Critical
libcrypto1.0  1.0.2h-r0  1.0.2h-r1   apk   CVE-2016-2177   Critical
libcrypto1.0  1.0.2h-r0  1.0.2o-r1   apk   CVE-2018-0732   High
libcrypto1.0  1.0.2h-r0  1.0.2k-r0   apk   CVE-2017-3731   High
libcrypto1.0  1.0.2h-r0  1.0.2j-r0   apk   CVE-2016-7052   High
libcrypto1.0  1.0.2h-r0  1.0.2i-r0   apk   CVE-2016-6304   High
libcrypto1.0  1.0.2h-r0  1.0.2h-r3   apk   CVE-2016-6302   High
libcrypto1.0  1.0.2h-r0  1.0.2i-r0   apk   CVE-2016-2183   High
libcrypto1.0  1.0.2h-r0  1.0.2h-r4   apk   CVE-2016-2181   High
libcrypto1.0  1.0.2h-r0  1.0.2h-r2   apk   CVE-2016-2180   High
libcrypto1.0  1.0.2h-r0  1.0.2h-r3   apk   CVE-2016-2179   High
libcrypto1.0  1.0.2h-r0  1.0.2q-r0   apk   CVE-2018-5407   Medium
libcrypto1.0  1.0.2h-r0  1.0.2o-r0   apk   CVE-2018-0739   Medium
libcrypto1.0  1.0.2h-r0  1.0.2o-r2   apk   CVE-2018-0737   Medium
libcrypto1.0  1.0.2h-r0  1.0.2q-r0   apk   CVE-2018-0734   Medium
libcrypto1.0  1.0.2h-r0  1.0.2o-r0   apk   CVE-2018-0733   Medium
libcrypto1.0  1.0.2h-r0  1.0.2n-r0   apk   CVE-2017-3738   Medium
libcrypto1.0  1.0.2h-r0  1.0.2n-r0   apk   CVE-2017-3737   Medium
libcrypto1.0  1.0.2h-r0  1.0.2m-r0   apk   CVE-2017-3736   Medium
libcrypto1.0  1.0.2h-r0  1.0.2m-r0   apk   CVE-2017-3735   Medium
libcrypto1.0  1.0.2h-r0  1.0.2k-r0   apk   CVE-2017-3732   Medium
libcrypto1.0  1.0.2h-r0  1.0.2k-r0   apk   CVE-2016-7055   Medium
libcrypto1.0  1.0.2h-r0  1.0.2i-r0   apk   CVE-2016-6306   Medium
libcrypto1.0  1.0.2h-r0  1.0.2h-r1   apk   CVE-2016-2178   Medium
libssl1.0     1.0.2h-r0  1.0.2h-r3   apk   CVE-2016-6303   Critical
libssl1.0     1.0.2h-r0  1.0.2h-r3   apk   CVE-2016-2182   Critical
libssl1.0     1.0.2h-r0  1.0.2h-r1   apk   CVE-2016-2177   Critical
libssl1.0     1.0.2h-r0  1.0.2o-r1   apk   CVE-2018-0732   High
libssl1.0     1.0.2h-r0  1.0.2k-r0   apk   CVE-2017-3731   High
libssl1.0     1.0.2h-r0  1.0.2j-r0   apk   CVE-2016-7052   High
libssl1.0     1.0.2h-r0  1.0.2i-r0   apk   CVE-2016-6304   High
libssl1.0     1.0.2h-r0  1.0.2h-r3   apk   CVE-2016-6302   High
libssl1.0     1.0.2h-r0  1.0.2i-r0   apk   CVE-2016-2183   High
libssl1.0     1.0.2h-r0  1.0.2h-r4   apk   CVE-2016-2181   High
libssl1.0     1.0.2h-r0  1.0.2h-r2   apk   CVE-2016-2180   High
libssl1.0     1.0.2h-r0  1.0.2h-r3   apk   CVE-2016-2179   High
libssl1.0     1.0.2h-r0  1.0.2q-r0   apk   CVE-2018-5407   Medium
libssl1.0     1.0.2h-r0  1.0.2o-r0   apk   CVE-2018-0739   Medium
libssl1.0     1.0.2h-r0  1.0.2o-r2   apk   CVE-2018-0737   Medium
libssl1.0     1.0.2h-r0  1.0.2q-r0   apk   CVE-2018-0734   Medium
libssl1.0     1.0.2h-r0  1.0.2o-r0   apk   CVE-2018-0733   Medium
libssl1.0     1.0.2h-r0  1.0.2n-r0   apk   CVE-2017-3738   Medium
libssl1.0     1.0.2h-r0  1.0.2n-r0   apk   CVE-2017-3737   Medium
libssl1.0     1.0.2h-r0  1.0.2m-r0   apk   CVE-2017-3736   Medium
libssl1.0     1.0.2h-r0  1.0.2m-r0   apk   CVE-2017-3735   Medium
libssl1.0     1.0.2h-r0  1.0.2k-r0   apk   CVE-2017-3732   Medium
libssl1.0     1.0.2h-r0  1.0.2k-r0   apk   CVE-2016-7055   Medium
libssl1.0     1.0.2h-r0  1.0.2i-r0   apk   CVE-2016-6306   Medium
libssl1.0     1.0.2h-r0  1.0.2h-r1   apk   CVE-2016-2178   Medium
musl          1.1.14-r9  1.1.14-r13  apk   CVE-2016-8859   Critical
musl          1.1.14-r9  1.1.14-r16  apk   CVE-2017-15650  High
musl-utils    1.1.14-r9  1.1.14-r13  apk   CVE-2016-8859   Critical
musl-utils    1.1.14-r9  1.1.14-r16  apk   CVE-2017-15650  High
zlib          1.2.8-r2   1.2.11-r0   apk   CVE-2016-9843   Critical
zlib          1.2.8-r2   1.2.11-r0   apk   CVE-2016-9841   Critical
zlib          1.2.8-r2   1.2.11-r0   apk   CVE-2016-9842   High
zlib          1.2.8-r2   1.2.11-r0   apk   CVE-2016-9840   High
```



**After:**
```
$ grype --only-fixed my_prometheus_amqp_proxy

No vulnerabilities found
```